### PR TITLE
fix: keep header if include it as file head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,10 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - uses: denoland/setup-deno@041b854f97b325bd60e53e9dc2de9cb9f9ac0cba # v1.1.4
       - run: deno task lint
+  deno_test:
+    runs-on: ubuntu-latest
+    needs: deno_fmt
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: denoland/setup-deno@041b854f97b325bd60e53e9dc2de9cb9f9ac0cba # v1.1.4
+      - run: deno test --allow-read --allow-write --allow-env --allow-net=jsr.io --allow-sys=cpus

--- a/cli.ts
+++ b/cli.ts
@@ -1,8 +1,6 @@
 import { Command } from "jsr:@cliffy/command@1.0.0-rc.4";
 import { resolve, toFileUrl } from "jsr:@std/path@0.225.1";
-
-import { collectDirectDependencies } from "./collect.ts";
-import { replaceStdToJsr } from "./regexp.ts";
+import { process } from "./process.ts";
 
 const command = new Command()
   .name("replace-std-to-jsr")
@@ -24,22 +22,6 @@ const command = new Command()
       }
     }
   });
-
-/**
- * Process the given file
- *
- * @param filename The filename
- * @returns The replaced file content
- */
-async function process(filename: URL): Promise<string> {
-  const deps = collectDirectDependencies(filename.pathname);
-  for (const dep of deps) {
-    await replaceStdToJsr(dep);
-  }
-
-  return deps.at(0)?.statement.getSourceFile().getText() ??
-    Deno.readTextFileSync(filename);
-}
 
 if (import.meta.main) {
   await command

--- a/process.test.ts
+++ b/process.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "jsr:@std/assert@0.225.1";
+import { toFileUrl } from "jsr:@std/path@0.225.1";
+import dedent from "npm:dedent@1.5.3";
+import { process } from "./process.ts";
+
+Deno.test("test for process.ts", async (t) => {
+  await t.step("If include https://deno.land/std, replace it.", async () => {
+    const dummyFile = Deno.makeTempFileSync();
+    const fileContent =
+      `import * as Path from "https://deno.land/std@0.224.0/path/mod.ts";`;
+    Deno.writeTextFileSync(dummyFile, fileContent);
+    const expected = `import * as Path from "jsr:@std/path@0.224.0";`;
+    assertEquals(await process(toFileUrl(dummyFile)), expected);
+  });
+
+  await t.step("If file has not deno.land/std, keep it.", async () => {
+    const dummyFile = Deno.makeTempFileSync();
+    const fileContent = `import * as Path from "jsr:@std/path@0.224.0";`;
+    Deno.writeTextFileSync(dummyFile, fileContent);
+    assertEquals(await process(toFileUrl(dummyFile)), fileContent);
+  });
+
+  await t.step("If include comment as file header, keep it.", async () => {
+    const dummyFile = Deno.makeTempFileSync();
+    const fileContent = dedent`
+      // hogehoge
+      import * as Path from "https://deno.land/std@0.224.0/path/mod.ts";
+    `.trim();
+    Deno.writeTextFileSync(dummyFile, fileContent);
+
+    const expected = dedent`
+      // hogehoge
+      import * as Path from "jsr:@std/path@0.224.0";
+    `.trim();
+
+    assertEquals(await process(toFileUrl(dummyFile)), expected);
+  });
+});

--- a/process.ts
+++ b/process.ts
@@ -1,0 +1,18 @@
+import { collectDirectDependencies } from "./collect.ts";
+import { replaceStdToJsr } from "./regexp.ts";
+
+/**
+ * Process the given file
+ *
+ * @param filename The filename
+ * @returns The replaced file content
+ */
+export async function process(filename: URL): Promise<string> {
+  const deps = collectDirectDependencies(filename.pathname);
+  for (const dep of deps) {
+    await replaceStdToJsr(dep);
+  }
+
+  return deps.at(0)?.statement.getSourceFile().getFullText() ??
+    Deno.readTextFileSync(filename);
+}


### PR DESCRIPTION
close #22

Original use `getText`, it seems like skip file header comment.

So, replace it as `getFullText`.


- **fix: keep file header comment**
- **test: add sample e2e testing**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated Deno tests to the CI workflow, ensuring higher code quality and reliability.

- **Refactor**
  - Refactored the `process` function to improve code maintainability and efficiency.

- **Tests**
  - Added comprehensive tests for the new `process` function to verify correct file content transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->